### PR TITLE
Add a workflow to build and push index.html

### DIFF
--- a/.github/workflows/generate-index.yaml
+++ b/.github/workflows/generate-index.yaml
@@ -1,0 +1,80 @@
+name: generate index
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '!*'
+    paths:
+      - '*'
+      - '!docs/index.html'
+      # TODO: Replace paths option
+      # - 'docs/lgtm/*'
+
+jobs:
+  build:
+    name: generate index.html
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: checkout
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: generate index
+        shell: bash
+        run: .github/workflows/generate-index/generate-index.sh
+
+      - name: upload index.html
+        uses: actions/upload-artifact@v1
+        with:
+          name: index
+          path: docs/index.html
+
+  deploy:
+    name: deploy index.html
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: checkout
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: download index.html
+        uses: actions/download-artifact@v1
+        with:
+          name: index
+          path: docs
+
+      - name: configure ssh
+        shell: bash
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          ssh-keyscan -t rsa github.com > ~/.ssh/known_hosts
+          echo "${DEPLOY_KEY}" > ~/.ssh/id_rsa
+          chmod 400 ~/.ssh/id_rsa
+
+      - name: configure git
+        shell: bash
+        run: |
+          git config user.name $(git log -1 --pretty=format:"%cn")
+          git config user.email $(git log -1 --pretty=format:"%ce")
+          git remote rm origin
+          git remote add origin git@github.com:${GITHUB_REPOSITORY}.git
+
+      - name: git push
+        shell: bash
+        run: |
+          branch=${GITHUB_REF#refs/heads/}
+          git checkout -b $branch
+          git add docs/index.html
+          git commit -m ":bookmark_tabs: Automated index generation at $(date --iso-8601=seconds)"
+          git push -u origin $branch
+
+

--- a/.github/workflows/generate-index/generate-index.sh
+++ b/.github/workflows/generate-index/generate-index.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eu
+
+lgtms=$(ls -t docs/lgtm/)
+
+cat <<HTML > docs/index.html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Ruby's LGTM List</title>
+</head>
+<body>
+  <ul>
+HTML
+
+for lgtm in $lgtms; do
+  cat <<HTML >> docs/index.html
+    <li><a href="./lgtm/$lgtm">lgtm/$lgtm</a></li>
+HTML
+done
+
+cat <<HTML >> docs/index.html
+  </ul>
+</body>
+</html>
+HTML


### PR DESCRIPTION
lgtm画像からlgtm画像のリストのHTMLをindex.htmlとして生成し、pushするGitHub ActionsのWorkflowを作成しました。

最初のindex.htmlが作成されたら、`on.push.paths`を`docs/lgtm/*`に変更してlgtm画像がpushされたときのみWorkflowを実行するようにします。